### PR TITLE
update SSL options for windows

### DIFF
--- a/http.c
+++ b/http.c
@@ -169,7 +169,14 @@ static Janet c_send_request(int32_t argc, Janet *argv) {
     // response headers
     curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, curl_callback);
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, (void *)&headers);
-
+	  
+    // set SSL behavior options
+    //
+    // Tell libcurl to use the operating system's native CA store for certificate verification. 
+    // Works only on Windows when built to use OpenSSL. 
+    // This option is experimental and behavior is subject to change. (Added in 7.71.0) 
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+  
     // send request
     res = curl_easy_perform(curl);
 
@@ -186,7 +193,7 @@ static Janet c_send_request(int32_t argc, Janet *argv) {
       janet_table_put(response_table, janet_ckeywordv("body"), janet_wrap_string(janet_string((const uint8_t *)body.memory, body.size)));
       janet_table_put(response_table, janet_ckeywordv("headers"), janet_wrap_string(janet_string((const uint8_t *)headers.memory, headers.size)));
     }
-
+    
     /* cleanup */
     curl_easy_cleanup(curl);
     curl_slist_free_all(curl_slist);

--- a/project.janet
+++ b/project.janet
@@ -11,12 +11,12 @@
   :x64 { 
     :download-url "https://curl.se/windows/dl-7.75.0_4/curl-7.75.0_4-win64-mingw.zip"
     :lib-path     "./curl/curl-7.75.0-win64-mingw/lib/"
-    :bin-files    "./curl/curl-7.75.0-win64-mingw/bin/libcurl-x64*"
+    :bin-path     "./curl/curl-7.75.0-win64-mingw/bin/"
     :include-path "./curl/curl-7.75.0-win64-mingw/include/" }
   :x86 {
     :download-url "https://curl.se/windows/dl-7.75.0_4/curl-7.75.0_4-win32-mingw.zip"
     :lib-path     "./curl/curl-7.75.0-win32-mingw/lib/"
-    :bin-files    "./curl/curl-7.75.0-win32-mingw/bin/libcurl*"
+    :bin-path     "./curl/curl-7.75.0-win32-mingw/bin/"
     :include-path "./curl/curl-7.75.0-win32-mingw/include/" }
   })
 
@@ -56,7 +56,7 @@
     "Expand-Archive -Force -Path curl.zip -DestinationPath curl"] :p))
 
 (defn windows-install-curl-dlls []
-  (def dll-files (string/replace-all "/" "\\" (curl-paths :bin-files)))
+  (def dll-files (string/replace-all "/" "\\" (curl-paths :bin-path "libcurl-x64*")))
   (print "copy " dll-files " to " JANET_BINPATH)
   (os/execute 
     ["cmd.exe" "/c" "copy" dll-files JANET_BINPATH] :p))


### PR DESCRIPTION
Hi Sean,

I have discovered another problem under windows. HTTPS calls did not work. I had not tested this :(

Now I have set the CURLOPT_SSL_OPTIONS to CURLSSLOPT_NATIVE_CA for this. 
Maybe you can test if this has an effect in a Linux environment? Actually this option should only matter for Windows, 
if I understood the documentation correctly. 

That is one option, the other option would be to set the CURLOPT_CAINFO option and to set the path to the curl-ca-bundle.crt file.
First I also copied this curl-ca-bundle.crt to the JANET_BINPATH and set the options to this path. But this would be more cumbersome, because I would have to do a special handling for Windows again.

----------------------------------------------------------------------------------------------------------------------
**Unfortunately I discovered another serious problem under windows. It has nothing to do with SSL. Unfortunately I haven't found a solution yet.**

The problem is, when I call the c_send_request function for the second time, the program crashes on the second call of **curl_global_cleanup();**
If I comment out this function call, the c_send_request  this function runs as expected. 
But that can't be the right way :( Unfortunately I don't have a solution for it yet.

The documentation for libcurl has the following note:
"curl_global_cleanup does not block waiting for any libcurl-created threads to terminate (such as threads used for name resolving). If a module containing libcurl is dynamically unloaded while libcurl-created threads are still running then your program may crash or other corruption may occur. We recommend you do not run libcurl from any module that may be unloaded dynamically. This behavior may be addressed in the future. "

I think somehow here is the problem? 

**Edit:**
Here is also another ticket about a similar problem? Maybe the same?
https://github.com/curl/curl/issues/997#issuecomment-245512129

**Maybe don't merge this pull request after all.**  
I will try a reproduce the problem in the next days,  without a dependency to Janet. 
Maybe the problem has nothing to do with Janet itself. 
I think I also need to understand the Microsoft compiler and linker a bit better. 
libcurl can somehow be linked statically or danamically (libcurl.a (for static linking) and libcurldll.a (for dynamic linking)).

Sorry, I thought it would be easier. 


Greetings

Jan-Felix