### PR TITLE
Handle libcurl errors gracefully

### DIFF
--- a/http_lib.janet
+++ b/http_lib.janet
@@ -14,7 +14,7 @@
 
 
 (defn parse-headers [response]
-  (let [str (get response :headers)]
+  (let [str (get response :headers "")]
     (->> (string/split "\r\n" str)
          (filter |(string/find ":" $))
          (mapcat |(string/split ":" $ 0 2))
@@ -33,6 +33,8 @@
         options (update options :headers prep-headers)
         response (send-request url options)
         headers (parse-headers response)]
+    (if-let [error-msg (response :error)]
+      (errorf "%s" error-msg))
     (merge response {:headers headers})))
 
 


### PR DESCRIPTION
Currently when libcurl  throws error, `http` raises error on parsing headers without giving further explanation what went wrong, e.g.:

```
repl:3:> (http/get "http://127.0.0.1:8080")
error: bad slot #1, expected string|symbol|keyword|buffer, got nil
  in string/split [src/core/string.c] on line 434
  in parse-headers [http_lib.janet] on line 18, column 10
  in request [http_lib.janet] (tailcall) on line 35, column 17
  in _thunk [repl] (tailcall) on line 3, column 1
```

After applying this patch the same error(server not accepting connections) would manifest like this:

```
repl:2:> (http/get "http://127.0.0.1:8080")
error: Couldn't connect to server
  in errorf [boot.janet] on line 165, column 3
  in request [http_lib.janet] (tailcall) on line 37, column 7
  in _thunk [repl] (tailcall) on line 2, column 1
```