### PR TITLE
Add option to specify http request port

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Send get requests!
 (http/post "example.com" "param1=value1&param2=value2")
 ```
 
+specify the request port!
+
+```clojure
+(http/get "localhost" "param1=value1&param2=value2" :port 8080)
+```
+
 follow redirects!
 
 ```clojure

--- a/http.c
+++ b/http.c
@@ -46,6 +46,13 @@ static Janet c_send_request(int32_t argc, Janet *argv) {
   const uint8_t *url = janet_getstring(argv, 0);
   JanetTable *options = janet_gettable(argv, 1);
 
+  Janet janet_port = janet_table_get(options, janet_ckeywordv("port"));
+  long port = 80;
+
+  if (janet_checktype(janet_port, JANET_NUMBER)) {
+    port = (long)janet_unwrap_integer(janet_port);
+  }
+
   Janet janet_follow_redirects = janet_table_get(options, janet_ckeywordv("follow-redirects"));
   int follow_redirects = 0;
 
@@ -122,6 +129,9 @@ static Janet c_send_request(int32_t argc, Janet *argv) {
 
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, url);
+
+    // set port
+    curl_easy_setopt(curl, CURLOPT_PORT, port);
 
     // set http method
     if(method) {


### PR DESCRIPTION
Added a few lines to check for the "port" keyword in the argv struct and set the request port accordingly in curl opts.